### PR TITLE
refactor: improve IRC mode avatar and media removal

### DIFF
--- a/content.js
+++ b/content.js
@@ -61,77 +61,97 @@ chrome.storage.sync.get(['flagsToHide', 'wordsToHide', 'filterAds', 'ircMode', '
     });
   }
 
+  function removeAvatarParentDivs() {
+
+    const avatarElements = document.querySelectorAll('[data-testid="Tweet-User-Avatar"]');
+
+    // Loop through all matching elements
+    avatarElements.forEach(avatarElement => {
+      const outerDiv = avatarElement.parentElement
+
+      if (outerDiv) {
+        outerDiv.remove();
+      }
+    });
+  }
+
+
   // Function to apply IRC mode
   function applyIRCMode() {
     if (ircMode) {
       console.log('Applying IRC Mode styles');
+      removeAvatarParentDivs();
 
-      // Apply global styles with updated selectors
-      styleTag.textContent = `
-        /* Profile pictures (background-image divs) */
-        div[data-testid="Tweet-User-Avatar"] div[style*="profile_images"],
-        div[class*="r-1ny4l3l"] div[style*="profile_images"] {
-          background-image: none !important;
-          display: none !important;
-        }
+      const tweetElements = document.querySelectorAll('[data-testid="tweet"]');
 
-        /* Profile pictures (img tags) */
-        div[data-testid="Tweet-User-Avatar"] img[src*="profile_images"],
-        div[class*="r-1ny4l3l"] img[src*="profile_images"],
-        div[class*="r-1ny4l3l"] img.css-9pa8cd,
-        img[src*="profile_images"] {
-          display: none !important;
-        }
+      const imageElements = document.querySelectorAll('[aria-label="Image"]');
+      const testCondensedMedias = document.querySelectorAll('[data-testid="testCondensedMedia"]')
+      const articleImgs = document.querySelectorAll('[data-testid="article-cover-image"]')
+      const linkImgs = document.querySelectorAll('[tabindex="0"][role="link"]')
+      
+      const smallMedias = document.querySelectorAll('[data-testid="card.layoutSmall.media"]')
+      const largeMedias = document.querySelectorAll('[data-testid="card.layoutLarge.media"]')
 
-        /* Tweet images (img tags) */
-        div[class*="r-1wyyakw"] img[src*="media"],
-        div[class*="r-1wyyakw"] img.css-9pa8cd {
-          display: none !important;
-        }
-
-        /* Tweet images (background-image divs) */
-        div[class*="r-1wyyakw"][style*="media"] {
-          background-image: none !important;
-          display: none !important;
-        }
-
-        /* Videos and thumbnails */
-        video,
-        div[aria-label*="media"] video,
-        div[aria-label*="media"] img[src*="media"],
-        div[class*="r-1wyyakw"] video,
-        div[class*="r-1wyyakw"] img[src*="media"] {
-          display: none !important;
-        }
-      `;
-
-      // Fallback: Directly hide elements
-      document.querySelectorAll('div[data-testid="Tweet-User-Avatar"] div[style*="profile_images"], div[class*="r-1ny4l3l"] div[style*="profile_images"]').forEach(div => {
-        div.style.backgroundImage = 'none';
-        div.style.display = 'none';
-        console.log('Hiding profile pic (background-image div):', div.getAttribute('style'));
+      linkImgs.forEach(element => {
+        element.parentElement.remove();
       });
 
-      document.querySelectorAll('div[data-testid="Tweet-User-Avatar"] img[src*="profile_images"], div[class*="r-1ny4l3l"] img[src*="profile_images"], div[class*="r-1ny4l3l"] img.css-9pa8cd, img[src*="profile_images"]').forEach(img => {
-        img.style.display = 'none';
-        console.log('Hiding profile pic (img):', img.src);
+      smallMedias.forEach(element => {
+        element.remove();
       });
 
-      document.querySelectorAll('div[class*="r-1wyyakw"] img[src*="media"], div[class*="r-1wyyakw"] img.css-9pa8cd').forEach(img => {
-        img.style.display = 'none';
-        console.log('Hiding tweet image (img):', img.src);
+      largeMedias.forEach(element => {
+        element.remove();
       });
 
-      document.querySelectorAll('div[class*="r-1wyyakw"][style*="media"]').forEach(div => {
-        div.style.backgroundImage = 'none';
-        div.style.display = 'none';
-        console.log('Hiding tweet image (background-image div):', div.getAttribute('style'));
+      articleImgs.forEach(element => {
+        element.parentElement.remove();
+      });
+      
+      testCondensedMedias.forEach(element => {
+        element.remove();
       });
 
-      document.querySelectorAll('video, div[aria-label*="media"] video, div[aria-label*="media"] img[src*="media"], div[class*="r-1wyyakw"] video, div[class*="r-1wyyakw"] img[src*="media"]').forEach(el => {
-        el.style.display = 'none';
-        console.log('Hiding video/thumbnail:', el.tagName, el.src || el.poster);
+      imageElements.forEach(element => {
+        element.remove();
       });
+
+      const tweetPhotos = document.querySelectorAll('[data-testid="tweetPhoto"]');
+
+      tweetPhotos.forEach(element => {
+        element.remove();
+      });
+
+      tweetElements.forEach(tweet => {
+
+        const photoLinks = tweet.querySelectorAll('a[href*="photo"]');
+
+        const childWithPadding = tweet.querySelector('[style="padding-bottom: 56.25%;"]');
+        
+        if (childWithPadding && photoLinks) {
+            childWithPadding.remove();
+        }
+
+        // for img groups
+        if (photoLinks.length > 1) {
+          photoLinks.forEach(link => {
+            const imgContainer = link.parentElement.parentElement.parentElement;
+            if (imgContainer) {
+              console.log(imgContainer);
+              
+              imgContainer.remove();  // Remove the parent element of the link
+            }
+          });
+        } else {
+          console.log("photoLinks length" + ":" + photoLinks.length);
+          
+          // for single img
+          photoLinks.forEach(link => {
+            link.remove();
+          });
+        }
+      });
+
     } else {
       console.log('Removing IRC Mode styles');
       styleTag.textContent = '';


### PR DESCRIPTION
- replace CSS-based hiding with direct DOM removal for better performance
- add specific targeting for various media elements (photos, articles, cards)
- implement removeAvatarParentDivs() function to fully remove avatars
- remove tweet photo containers and links more comprehensively
- fix handling of both single and grouped images

![Screenshot 2025-03-29 at 2 33 22 PM](https://github.com/user-attachments/assets/c5706301-af8e-4ff4-a89a-82100eac9150)
